### PR TITLE
save absolute path in config._cache_dir (part1)

### DIFF
--- a/trankit/pipeline.py
+++ b/trankit/pipeline.py
@@ -152,9 +152,11 @@ class Pipeline:
             self._tagbatchsize = 12
 
         if self._cache_dir is None:
-            master_config._cache_dir = 'cache/trankit'
+            local_cache_dir = 'cache/trankit'
         else:
-            master_config._cache_dir = self._cache_dir
+            local_cache_dir = self._cache_dir
+            
+        master_config._cache_dir = os.path.abspath(local_cache_dir)
 
         if not os.path.exists(master_config._cache_dir):
             os.makedirs(master_config._cache_dir, exist_ok=True)

--- a/trankit/pipeline.py
+++ b/trankit/pipeline.py
@@ -157,9 +157,7 @@ class Pipeline:
             local_cache_dir = self._cache_dir
             
         master_config._cache_dir = os.path.abspath(local_cache_dir)
-
-        if not os.path.exists(master_config._cache_dir):
-            os.makedirs(master_config._cache_dir, exist_ok=True)
+        ensure_dir(master_config._cache_dir)
 
         master_config.wordpiece_splitter = XLMRobertaTokenizer.from_pretrained(master_config.embedding_name,
                                                                                cache_dir=os.path.join(


### PR DESCRIPTION
Earlier relative path could be put in config that leads to errors on any `os.chdir()` call to different directory.