### PR TITLE
Remove torch<1.8.0 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     ],
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['numpy', 'protobuf', 'requests', 'torch>=1.6.0,<1.8.0', 'tqdm>=4.27', 'langid==1.1.6', 'filelock', 'tokenizers>=0.7.0', 'regex != 2019.12.17', 'packaging', 'sentencepiece', 'sacremoses'],
+    install_requires=['numpy', 'protobuf', 'requests', 'torch>=1.6.0', 'tqdm>=4.27', 'langid==1.1.6', 'filelock', 'tokenizers>=0.7.0', 'regex != 2019.12.17', 'packaging', 'sentencepiece', 'sacremoses'],
     entry_points={
     },
 )


### PR DESCRIPTION
This removes the `torch<1.8.0` install requirement in `setup.py`, as suggested [here](https://github.com/nlp-uoregon/trankit/issues/33).

We'd like to do this to be able to use Trankit with later versions of PyTorch.  We've verified that it successfully serves predictions with Python 3.8.9 and `torch==1.11.0`.