### PR TITLE
fix incompatibility with modern immutability check of @dataclass

### DIFF
--- a/trankit/adapter_transformers/adapter_config.py
+++ b/trankit/adapter_transformers/adapter_config.py
@@ -12,7 +12,7 @@ from .adapter_utils import AdapterType, get_adapter_config_hash, resolve_adapter
 logger = logging.getLogger(__name__)
 
 
-@dataclass()
+@dataclass
 class InvertibleAdapterConfig(Mapping):
     block_type: str
     non_linearity: str
@@ -37,6 +37,9 @@ class InvertibleAdapterConfig(Mapping):
 
     def __len__(self):
         return len(self.__dict__)
+    
+    def __hash__(self):
+        return hash(self.__dict__)
 
 
 @dataclass
@@ -75,6 +78,10 @@ class AdapterConfig(Mapping):
 
     def __len__(self):
         return len(self.__dict__)
+    
+    # not necessary but added for future-proofing
+    def __hash__(self):
+        return hash(self.__dict__)
 
     def to_dict(self):
         return asdict(self)


### PR DESCRIPTION
This fixes #73.

I continued the policy of exposing self.__dict__ and added hash functions for both the invertible adapter config and the regular adapter config.
